### PR TITLE
Fixed issue with Arial font error on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 npm-debug.*
 config.json
 .vscode
+.idea

--- a/src/screens/word/WordScreen.js
+++ b/src/screens/word/WordScreen.js
@@ -3,7 +3,7 @@ import WORD_SET from "../../../assets/words.json";
 import Swiper from "react-native-swiper";
 import moment from "moment";
 
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Text } from "react-native";
 
 import { Constants } from "expo";
 
@@ -47,6 +47,8 @@ class WordScreen extends Component {
         <Switcher index={currentIndex} />
         <Swiper
           showsButtons
+          nextButton={<Text style={styles.buttonText}>&gt;</Text>}
+          prevButton={<Text style={styles.buttonText}>&lt;</Text>}
           index={1}
           loop={false}
           showsPagination={true}
@@ -67,6 +69,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: "white"
+  },
+  buttonText: {
+    fontSize: 28,
+    fontWeight: "bold",
+    color: "#356AA0"
   }
 });
 


### PR DESCRIPTION
Issue with Arial font not being available on Android.
See [comment](https://github.com/leecade/react-native-swiper/issues/444#issuecomment-332635663)

Issue with Swiper component and the navigation buttons.  Tried to load an arial.ttf alongside OpenSans-Bold in WordView.js but it did not solve the issue.  So implemented the solution as in the comment linked above.

![image](https://user-images.githubusercontent.com/189738/32026997-8fb5fa84-b9de-11e7-8d3d-55934bd36170.png)
